### PR TITLE
test(command): add JUnit tests for SetWorkoutGoalCommand and ViewWorkoutGoalCommand

### DIFF
--- a/src/test/java/seedu/mama/command/SetWorkoutGoalCommandTest.java
+++ b/src/test/java/seedu/mama/command/SetWorkoutGoalCommandTest.java
@@ -2,6 +2,7 @@ package seedu.mama.command;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.mama.model.Entry;
 import seedu.mama.model.EntryList;
 import seedu.mama.model.WeekCheck;
@@ -18,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for workout goal feature:
- *  - SetWorkoutGoalCommand parsing + execution
- *  - Integration with AddWorkoutCommand (reminders, remaining minutes)
+ * - SetWorkoutGoalCommand parsing + execution
+ * - Integration with AddWorkoutCommand (reminders, remaining minutes)
  */
 public class SetWorkoutGoalCommandTest {
 

--- a/src/test/java/seedu/mama/command/ViewWorkoutGoalCommandTest.java
+++ b/src/test/java/seedu/mama/command/ViewWorkoutGoalCommandTest.java
@@ -2,7 +2,7 @@ package seedu.mama.command;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import seedu.mama.model.Entry;
+
 import seedu.mama.model.EntryList;
 import seedu.mama.model.WeekCheck;
 import seedu.mama.model.WorkoutEntry;
@@ -12,7 +12,6 @@ import seedu.mama.storage.Storage;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ViewWorkoutGoalCommandTest {


### PR DESCRIPTION
Branch: test/Set-Workout-Goal-JUnit-Test
Linked Issue: #96 #97 
Closes: #96 #97 

### **Summary:**
This PR adds comprehensive JUnit 5 coverage for the Workout Goal feature, including tests for setting weekly goals and viewing weekly progress. It validates both command parsing/execution (SetWorkoutGoalCommand) and user-facing progress output (ViewWorkoutGoalCommand), plus integration with AddWorkoutCommand.

### **Changes Made:**
**- Added SetWorkoutGoalCommandTest under src/test/java/seedu/mama/command/**

- Valid goal sets a WORKOUT_GOAL entry with correct minutes.

- fromInput("workout goal <minutes>") parses correctly.

- Invalid inputs throw CommandException: missing minutes, non-numeric, zero/negative.

- Integration: adding a workout with no goal shows a reminder; with a goal shows remaining minutes.

**- Added ViewWorkoutGoalCommandTest under src/test/java/seedu/mama/command/**

- No goal this week → reminder message + empty/week list header shown.

- Goal this week + workouts this week → totals computed correctly; remaining minutes reflected; workouts listed.

- Automatic Monday reset → last week’s goal is ignored for the current week.

**### Acceptance Criteria:**
- Running gradle test executes both SetWorkoutGoalCommandTest and ViewWorkoutGoalCommandTest successfully.

- At least one test fails if parsing, execution, weekly aggregation, or Monday reset logic is broken.

- Tests are deterministic (avoid timestamp flakiness by checking stable substrings) and do not require manual storage setup (use a temporary test storage path).